### PR TITLE
adds initial documentation and resource list

### DIFF
--- a/docs/resource_list/json_formatting.md
+++ b/docs/resource_list/json_formatting.md
@@ -1,0 +1,8 @@
+# JSON Formatting for the Resource List
+***
+- Each resource `resource_object` will have the following set of attributes:
+  - `"title"`: The title of the resource; a `String`
+  - `"subject_tags"`: Primary descriptive tags of the resource, i.e. the language being discussed and/or the specific disciplineary focus; an array of `String`s
+  - `"author"`: The author or place of origin of the resource; a `String`
+  - `"link_to_resource"`: The link to the resource; a `String`
+  - `"other_tags"`: Secondary descriptive tags of the resource, i.e. information on the medium of delivery or audience focus; an array of `String`s

--- a/resource_list.json
+++ b/resource_list.json
@@ -1,0 +1,11 @@
+{
+    "resources": {
+        "resource_name": {
+            "title": "title_of_resource",
+            "subject_tags": ["python", "tdd", "tag3", "..."],
+            "author": "name_of_author_and/or_organization_that_created_the_resource",
+            "link_to_resource": "https.whatever%20it%20is.com",
+            "other_tags": ["podcast", "beginner-centric", "practice-problems", "pdf", "series", "..."]
+        }
+    }
+}


### PR DESCRIPTION
Adds a .json file, which currently just has a template for a 'resource' object. In addition adds a folder 'docs' to hold any documentation we want to use/write; this folder will be initialized with some bare-bones documentation for the resource_list.json file.